### PR TITLE
chore: drop ARMv7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       -
         name: Detect platforms
         run: |
-          platforms="linux/amd64,linux/arm64,linux/arm/v7"
+          platforms="linux/amd64,linux/arm64"
           echo "PLATFORMS=${platforms}" >> $GITHUB_ENV
       -
         name: Set up QEMU


### PR DESCRIPTION
Since we don't provide any ARMv7 PostgreSQL image doesn't make sense to provide a PgBouncer for ARMv7.

Closes #27

Signed-off-by: Jonathan Gonzalez V <jonathan.abdiel@gmail.com>