### PR TITLE
ci: drop workaround for buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          # TODO: Remove workaround once https://github.com/docker/build-push-action/issues/761 is fixed
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
       -
         name: Log in to the GitHub Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>