### PR TITLE
ci: set default workflow permissions to read-all

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,8 @@ defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: read-all
+
 jobs:
   retrieve-versions:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Since we use the internal GitHub token to create the PRs no other permission is required.

Closes #57 