### PR TITLE
ci: use hosted runners when running from the cloudnative-pg org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   testbuild:
     name: Build and publish
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Relates to https://github.com/cloudnative-pg/cloudnative-pg/issues/10226