### PR TITLE
docs(ip): assign copyright to the Linux Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Pre-built images are available from the
 
 This software is available under [Apache License 2.0](LICENSE).
 
-Copyright The CloudNativePG Contributors.
+Copyright © contributors to CloudNativePG, established as CloudNativePG a Series of LF Projects, LLC.
 
 Licensing information of all the software included in the container images is
 in the `/usr/share/doc/*/copyright*` files.


### PR DESCRIPTION
Adopt the new attribution information for contributions to CloudNativePG:

```
Copyright © contributors to CloudNativePG, established as
CloudNativePG a Series of LF Projects, LLC.
```